### PR TITLE
Fix leaderboard responsive layout

### DIFF
--- a/posts/agentdeal.html
+++ b/posts/agentdeal.html
@@ -21,9 +21,10 @@
     .stat .value{font-size:2rem;font-weight:700;}
     .section-title{font-size:1.75rem;font-weight:700;text-align:center;margin:3rem 0 1.5rem;}
     table{width:100%;border-collapse:collapse;margin-bottom:4rem;}
-    th,td{padding:.75rem;border-bottom:1px solid #e5e5e5;text-align:center;font-size:.95rem;}
+    th,td{padding:.75rem;border-bottom:1px solid #e5e5e5;text-align:center;font-size:.95rem;word-break:break-word;}
     th{background:#f3f3f3;font-weight:600;}
     tbody tr:hover{background:#f9f9f9;}
+    .table-wrap{max-width:720px;width:100%;margin:0 auto;padding:0 1rem;overflow-x:auto;}
     footer{background:#000;color:#fff;padding:1.5rem;text-align:center;font-size:.875rem;}
     @media(max-width:600px){
       .stats{flex-direction:column;align-items:center;}
@@ -54,7 +55,7 @@
   </section>
 
   <h2 class="section-title">Leaderboard</h2>
-  <div style="overflow-x:auto;padding:0 1rem;">
+  <div class="table-wrap">
     <table id="leaderboard">
       <thead>
         <tr>


### PR DESCRIPTION
## Summary
- center the leaderboard section
- prevent text from overflowing on small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68823b42fa9c8320bcfe899d8ffcb78a